### PR TITLE
Crash running NUnit version 3 - there is no attribute called "name" i…

### DIFF
--- a/ReportUnit/Parser/NUnit.cs
+++ b/ReportUnit/Parser/NUnit.cs
@@ -32,7 +32,7 @@ namespace ReportUnit.Parser
             Report report = new Report();
 
             report.FileName = Path.GetFileNameWithoutExtension(resultsFile);
-            report.AssemblyName = doc.Root.Attribute("name").Value;
+            report.AssemblyName = doc.Root.Attribute( "name" ) != null ? doc.Root.Attribute("name").Value : null;
             report.TestRunner = TestRunner.NUnit;
 
             // run-info & environment values -> RunInfo


### PR DESCRIPTION
…n the root element.  Just check for null so we don't crash.