### PR TITLE
add NUnit console output to the status message

### DIFF
--- a/ReportUnit/Parser/NUnit.cs
+++ b/ReportUnit/Parser/NUnit.cs
@@ -181,7 +181,12 @@ namespace ReportUnit.Parser
                                 : "" 
                             : "";
 
-                    testSuite.TestList.Add(test);
+                   // add NUnit console output to the status message
+                   test.StatusMessage += tc.Element( "output" ) != null
+                     ? tc.Element( "output" ).Value
+                     : "";
+
+                   testSuite.TestList.Add(test);
                 });
 
                 testSuite.Status = ReportUtil.GetFixtureStatus(testSuite.TestList);


### PR DESCRIPTION
NUnit tests can also write out logging information to the console.   This can be useful information for diagnosing test suite failures.  I'm not sure on the ideal way to handle this - I simply added the output to the end of the StatusMessage.