### PR TITLE
Updated CopyrightMessage()

### DIFF
--- a/ReportUnit/Program.cs
+++ b/ReportUnit/Program.cs
@@ -14,6 +14,7 @@ namespace ReportUnit
 
     using Design;
     using Logging;
+    using System.Reflection;
 
     class Program
     {
@@ -113,7 +114,12 @@ namespace ReportUnit
 
         private static void CopyrightMessage()
         {
-            Console.WriteLine("\n--\nReportUnit v1.1. Report generator for the test-runner family.");
+            AssemblyName asm = Assembly.GetExecutingAssembly().GetName();
+            string name = asm.Name;
+            string version = "v" + asm.Version.ToString();
+
+            Console.WriteLine("\n--\n");
+            Console.WriteLine(name + " " + version + " Report generator for the test-runner family.");
             Console.WriteLine("http://reportunit.relevantcodes.com/");
             Console.WriteLine("Copyright (c) 2015 Anshoo Arora (Relevant Codes)");
             Console.WriteLine("Developers:  Anshoo Arora, Sandra Greenhalgh\n--\n");

--- a/ReportUnit/Program.cs
+++ b/ReportUnit/Program.cs
@@ -117,7 +117,7 @@ namespace ReportUnit
             string name = asm.Name;
             string version = "v" + asm.Version.ToString();
 
-            Console.WriteLine("\n--\n");
+            Console.WriteLine("\n--");
             Console.WriteLine(name + " " + version + " Report generator for the test-runner family.");
             Console.WriteLine("http://reportunit.relevantcodes.com/");
             Console.WriteLine("Copyright (c) 2015 Anshoo Arora (Relevant Codes)");

--- a/ReportUnit/Program.cs
+++ b/ReportUnit/Program.cs
@@ -10,7 +10,6 @@ namespace ReportUnit
 {
     using System;
     using System.IO;
-    using System.Linq;
 
     using Design;
     using Logging;


### PR DESCRIPTION
There was a mistake in the code where the console showed that the version was 1.1 when it was actually 1.2.  This was unexpected behavior, since the .exe at reportunit.relevantcodes.com was listed at version 1.2.  Minor refactoring is included as well.

Command line output showing v1.1:
![image](https://cloud.githubusercontent.com/assets/2008881/12698284/696791fe-c75e-11e5-93f7-e2df9c6057d3.png)

Download link showing 1.2:
![image](https://cloud.githubusercontent.com/assets/2008881/12698292/98eca720-c75e-11e5-99b1-6b1af396e211.png)

Here is what the updated output looks like showing the correct version:
![image](https://cloud.githubusercontent.com/assets/2008881/12698309/478675ae-c75f-11e5-8562-ecc453736761.png)

