### PR TITLE
- Fixed bugs parsing Categories in NUnit parser

### DIFF
--- a/cdn/reportunit.css
+++ b/cdn/reportunit.css
@@ -246,10 +246,10 @@ nav a.button-collapse {
 }
 .suite-list {
     overflow-y: scroll;
-    width: 500px;
+    width: 20%;
 }
 .suite-details {
-    left: 762px;
+    left: 21%;
     right: 1%;
 }
 .v-spacer {


### PR DESCRIPTION
**Categories not retrieved in NUnit parser**
1)  Changed parser to look for a "Categories" element instead of a property named "Category" (to match NUnit 2.6.4)
2)  Modified code to capture categories at the suite level for each test.  For example, a category of "SmokeTests" at the class level would not display at a category for the tests it contained
3)  Modified code to capture categories for parameterized tests.  Parameterized tests are grouped under a test-suite node with type "ParameterizedTest" (example below), so those categories were not captured

```
  <test-suite type="ParameterizedTest" name="MyTestMethod" executed="True" result="Success" success="True" time="0.205" asserts="0">
 <categories>
   <category name="SmokeTest" />
 </categories>
 <results>
   <test-case name="MyTests.MyTestMethod(param1)" executed="True" result="Success" success="True" time="0.096" asserts="2" />
   <test-case name="MyTests.MyTestMethod(param2)" executed="True" result="Success" success="True" time="0.107" asserts="2" />
 </results>
  </test-suite>
```

**Fixed CSS issue in File.cs template.  Large blank space was present between the suite list and suite detail (image below)**
1)  Changed .suite-list class to use percentage width instead of fixed width
2)  Changed .suite-details to use percentage for left position instead of fixed number of pixels

![image](https://cloud.githubusercontent.com/assets/8272609/13183081/1124b526-d703-11e5-9fae-e93be522aaa6.png)
