### PR TITLE
JUnit parser functionality to ReportUnit

### DIFF
--- a/ReportUnit.sln
+++ b/ReportUnit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 2013 for Windows Desktop
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReportUnit", "ReportUnit\ReportUnit.csproj", "{12B65E5C-465A-4EB5-BCDB-0F79224A9BCF}"
 EndProject

--- a/ReportUnit/Extensions/XElementExtensions.cs
+++ b/ReportUnit/Extensions/XElementExtensions.cs
@@ -1,0 +1,28 @@
+﻿namespace ReportUnit.Extensions
+{
+    using System.Xml.Linq;
+
+    /// <summary>
+    /// To avoid having to write the Null verification on every attribute in the report, this extension method provides
+    /// reusable code.
+    /// </summary>
+    public static class XElementExtensions
+    {
+        /// <summary>
+        /// Checks if an attribute with the specified name exists and returns it's value.
+        /// </summary>
+        /// <param name="element">
+        /// The element to get the attribute from.
+        /// </param>
+        /// <param name="attributeName">
+        /// The attribute name.
+        /// </param>
+        /// <returns>
+        /// The string value of the attribute if it's not null or string.Empty if it's null.
+        /// </returns>
+        public static string GetNullableAttribute(this XElement element, string attributeName)
+        {
+            return element.Attribute(attributeName) != null ? element.Attribute(attributeName).Value : string.Empty;
+        }
+    }
+}

--- a/ReportUnit/Parser/JUnit.cs
+++ b/ReportUnit/Parser/JUnit.cs
@@ -7,9 +7,7 @@
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Xml.Linq;
-
-    using RazorEngine.Compilation.ImpromptuInterface.Dynamic;
-
+    
     using ReportUnit.Extensions;
     using ReportUnit.Model;
     using ReportUnit.Utils;
@@ -80,11 +78,9 @@
             report.Duration = report.TestSuiteList.Sum(testSuite => testSuite.TestList.Sum(x => x.Duration));
 
             // if there's no <testsuites> root node this should be true.
-            if (singleSuite) 
+            if (singleSuite)
             {
-                report.StartTime = docRoot.Attribute("timestamp") != null
-                                       ? docRoot.Attribute("timestamp").Value
-                                       : string.Empty;
+                report.StartTime = docRoot.GetNullableAttribute("timestamp");
             }
             else
             {

--- a/ReportUnit/Parser/JUnit.cs
+++ b/ReportUnit/Parser/JUnit.cs
@@ -1,13 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Xml.Linq;
-using ReportUnit.Model;
-
-namespace ReportUnit.Parser
+﻿namespace ReportUnit.Parser
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using System.Xml.Linq;
+
+    using ReportUnit.Extensions;
+    using ReportUnit.Model;
+    using ReportUnit.Utils;
+
     internal class JUnit : IParser
     {
         public Report Parse(string filePath)
@@ -16,12 +19,271 @@ namespace ReportUnit.Parser
             {
                 throw new FileNotFoundException(string.Format("File {0} does not exist.", filePath));
             }
+            bool singleSuite = false;
 
             XDocument doc = XDocument.Load(filePath);
 
+            var docroot = doc.Root;
 
+            if (docroot == null)
+            {
+                throw new NullReferenceException(@"Could not read document root.");
+            }
 
-            return new Report();
+            var report = new Report();
+            report.FileName = Path.GetFileNameWithoutExtension(filePath);
+            report.TestRunner = TestRunner.JUnit;
+
+            var runInfo = this.CreateRunInfo(doc, report);
+            if (runInfo != null)
+            {
+                report.AddRunInfo(runInfo);
+            }
+
+            IEnumerable<XElement> suites = docroot.Descendants("testsuite");
+
+            var suitesList = suites as XElement[] ?? suites.ToArray();
+            if (suitesList.Any())
+            {
+                suitesList.AsParallel().ToList().ForEach(
+                    ts =>
+                        {
+                            var testSuite = new TestSuite();
+                            testSuite.Name = ts.GetNullableAttribute("name");
+                            testSuite.StartTime = ts.GetNullableAttribute("timestamp");
+
+                            // we will add host and test suite ID to description.
+                            var hostName = ts.GetNullableAttribute("hostname");
+                            var id = ts.GetNullableAttribute("id");
+                            if (hostName != string.Empty)
+                            {
+                                testSuite.Description = "Hostname: " + hostName;
+                            }
+
+                            if (id != string.Empty)
+                            {
+                                testSuite.Description += " Id: " + id;
+                            }
+
+                            var duration = ts.GetNullableAttribute("time");
+                            if (duration != string.Empty)
+                            {
+                                var parseResult = Regex.Replace(duration, @"[^0-9.]", "");
+                                testSuite.Duration = double.Parse(parseResult);
+                            }
+                            
+                            ts.Descendants("testcase").AsParallel().ToList().ForEach(
+                                tc =>
+                                    {
+                                        var test = new Test();
+                                        test.Name = tc.GetNullableAttribute("name");
+
+                                        var classCategory = tc.GetNullableAttribute("classname");
+                                        if (classCategory != string.Empty)
+                                        {
+                                            test.CategoryList.Add(classCategory);
+                                        }
+
+                                        var failureElement = tc.Descendants("failure").FirstOrDefault();
+                                        if (failureElement == null)
+                                        {
+                                            test.Status = Status.Passed;
+                                        }
+                                        else
+                                        {
+                                            test.Status = Status.Failed;
+                                            test.StatusMessage = failureElement.Value;
+                                            var typeAttribute = failureElement.GetNullableAttribute("type");
+                                            if (typeAttribute != string.Empty)
+                                                // we add the type attribute to the failure if it's present.
+                                            {
+                                                test.StatusMessage += " Type: " + typeAttribute;
+                                            }
+                                        }
+
+                                        var errorElement = tc.Descendants("error").FirstOrDefault();
+
+                                        if (errorElement != null)
+                                        {
+                                            // we overwrite the status because it means that there was an error.
+                                            test.Status = Status.Error;
+                                            test.StatusMessage += errorElement.Value;
+                                            // we add the type attribute if it's there.
+                                            var typeAttribute = errorElement.GetNullableAttribute("type");
+                                            if (typeAttribute != string.Empty)
+                                            {
+                                                test.StatusMessage += " Type: " + typeAttribute;
+                                            }
+                                        }
+
+                                        var systemOutElement = tc.Descendants("system-out").FirstOrDefault();
+                                        if (systemOutElement != null)
+                                        {
+                                            test.StatusMessage += " System-Out: " + systemOutElement.Value;
+                                        }
+
+                                        var systemErrElement = tc.Descendants("system-err").FirstOrDefault();
+                                        if (systemErrElement != null)
+                                        {
+                                            test.StatusMessage += " System-Err: " + systemErrElement.Value;
+                                        }
+
+                                        testSuite.TestList.Add(test);
+                                    });
+
+                            testSuite.Status = ReportUtil.GetFixtureStatus(testSuite.TestList);
+
+                            report.TestSuiteList.Add(testSuite);
+                        });
+            }
+            else
+            {
+                // some junit reports only contain one suite. so we try to get the results from that
+                if (doc.Descendants("testsuite") != null)
+                {
+                    singleSuite = true;
+                    var testSuites = doc.Descendants("testsuite");
+
+                    testSuites.AsParallel().ToList().ForEach(
+                        ts =>
+                        {
+                            var testSuite = new TestSuite();
+                            testSuite.Name = ts.GetNullableAttribute("name");
+                            testSuite.StartTime = ts.GetNullableAttribute("timestamp");
+
+                            // we will add host and test suite ID to description.
+                            var hostName = ts.GetNullableAttribute("hostname");
+                            var id = ts.GetNullableAttribute("id");
+                            if (hostName != string.Empty)
+                            {
+                                testSuite.Description = "Hostname: " + hostName;
+                            }
+
+                            if (id != string.Empty)
+                            {
+                                testSuite.Description += " Id: " + id;
+                            }
+
+                            var duration = ts.GetNullableAttribute("time");
+                            testSuite.Duration = duration == string.Empty ? 0 : double.Parse(duration);
+
+                            ts.Descendants("testcase").AsParallel().ToList().ForEach(
+                                tc =>
+                                {
+                                    var test = new Test();
+                                    test.Name = tc.GetNullableAttribute("name");
+
+                                    var classCategory = tc.GetNullableAttribute("classname");
+                                    if (classCategory != string.Empty)
+                                    {
+                                        test.CategoryList.Add(classCategory);
+                                    }
+
+                                    var failureElement = tc.Descendants("failure").FirstOrDefault();
+                                    if (failureElement == null)
+                                    {
+                                        test.Status = Status.Passed;
+                                    }
+                                    else
+                                    {
+                                        test.Status = Status.Failed;
+                                        test.StatusMessage = failureElement.Value;
+                                        var typeAttribute = failureElement.GetNullableAttribute("type");
+                                        if (typeAttribute != string.Empty)
+                                        // we add the type attribute to the failure if it's present to get more info.
+                                        {
+                                            test.StatusMessage += " Type: " + typeAttribute;
+                                        }
+                                    }
+
+                                    var errorElement = tc.Descendants("error").FirstOrDefault();
+
+                                    if (errorElement != null)
+                                    {
+                                        // we overwrite the status because it means that there was an error.
+                                        test.Status = Status.Error;
+                                        test.StatusMessage += errorElement.Value;
+                                        // we add the type attribute if it's there.
+                                        var typeAttribute = errorElement.GetNullableAttribute("type");
+                                        if (typeAttribute != string.Empty)
+                                        {
+                                            test.StatusMessage += " Type: " + typeAttribute;
+                                        }
+                                    }
+
+                                    var systemOutElement = tc.Descendants("system-out").FirstOrDefault();
+                                    if (systemOutElement != null)
+                                    {
+                                        test.StatusMessage += " System-Out: " + systemOutElement.Value;
+                                    }
+
+                                    var systemErrElement = tc.Descendants("system-err").FirstOrDefault();
+                                    if (systemErrElement != null)
+                                    {
+                                        test.StatusMessage += " System-Err: " + systemErrElement.Value;
+                                    }
+
+                                    testSuite.TestList.Add(test);
+                                });
+
+                            testSuite.Status = ReportUtil.GetFixtureStatus(testSuite.TestList);
+
+                            report.TestSuiteList.Add(testSuite);
+                        });
+                }
+            }
+
+            report.Total = report.TestSuiteList.Sum(testSuite => testSuite.TestList.Count);
+
+            report.Failed =
+                report.TestSuiteList.Sum(testSuite => testSuite.TestList.Count(x => x.Status == Status.Failed));
+
+            report.Errors = report.TestSuiteList.Sum(testSuite => testSuite.TestList.Count(x => x.Status == Status.Error));
+
+            report.Skipped = report.TestSuiteList.Sum(testSuite => testSuite.TestList.Count(x => x.Status == Status.Skipped));
+
+            report.Duration = report.TestSuiteList.Sum(testSuite => testSuite.TestList.Sum(x => x.Duration));
+
+            if (singleSuite)
+            {
+                report.StartTime = docroot.Attribute("timestamp") != null
+                                       ? docroot.Attribute("timestamp").Value
+                                       : string.Empty;
+            }
+            else
+            {
+                report.StartTime = report.TestSuiteList.First().StartTime;
+            }
+            
+            var testSuitePackageInfo =
+                doc.Descendants("testsuites")
+                    .Where(x => x.Attribute("failures") != null && x.Attribute("package") != null);
+
+            // avoid multiple enumerations of IEnumerable by casting to array.
+            var suitePackageInfo = testSuitePackageInfo as XElement[] ?? testSuitePackageInfo.ToArray();
+
+            report.StatusMessage = suitePackageInfo.Any() ? suitePackageInfo.First().Value : string.Empty;
+            report.CategoryList.Sort();
+
+            return report;
+        }
+
+        /// <summary>
+        /// The create run info.
+        /// </summary>
+        /// <param name="doc">
+        /// The doc.
+        /// </param>
+        /// <param name="report">
+        /// The report.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Dictionary"/>.
+        /// </returns>
+        private Dictionary<string, string> CreateRunInfo(XDocument doc, Report report)
+        {
+            return null;
+            //            throw new System.NotImplementedException();
         }
     }
 }

--- a/ReportUnit/Parser/JUnit.cs
+++ b/ReportUnit/Parser/JUnit.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using ReportUnit.Model;
+
+namespace ReportUnit.Parser
+{
+    internal class JUnit : IParser
+    {
+        public Report Parse(string filePath)
+        {
+            if (!System.IO.File.Exists(filePath))
+            {
+                throw new FileNotFoundException(string.Format("File {0} does not exist.", filePath));
+            }
+
+            XDocument doc = XDocument.Load(filePath);
+
+
+
+            return new Report();
+        }
+    }
+}

--- a/ReportUnit/Parser/TestRunner.cs
+++ b/ReportUnit/Parser/TestRunner.cs
@@ -7,6 +7,7 @@
         NUnit,
 		XUnitV1,
 		XUnitV2,
+        JUnit,
         Unknown
     }
 }

--- a/ReportUnit/ReportUnit.csproj
+++ b/ReportUnit/ReportUnit.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\XElementExtensions.cs" />
     <Compile Include="Logging\Level.cs" />
     <Compile Include="Logging\Log.cs" />
     <Compile Include="Logging\Logger.cs" />

--- a/ReportUnit/ReportUnit.csproj
+++ b/ReportUnit/ReportUnit.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Model\CompositeTemplate.cs" />
     <Compile Include="Parser\Gallio.cs" />
     <Compile Include="Parser\IParser.cs" />
+    <Compile Include="Parser\JUnit.cs" />
     <Compile Include="Parser\MSTest2010.cs" />
     <Compile Include="Parser\NUnit.cs" />
     <Compile Include="Parser\ParserFactory.cs" />
@@ -79,6 +80,10 @@
     <None Include="App.config" />
     <None Include="packages.config" />
     <None Include="Readme.md" />
+    <Content Include="Schemas\junit.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/ReportUnit/Schemas/junit.xsd
+++ b/ReportUnit/Schemas/junit.xsd
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped" type="xs:string"/>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="assertions" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="classname" type="xs:string" use="optional"/>
+            <xs:attribute name="status" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="skipped" type="xs:string" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
+            <xs:attribute name="hostname" type="xs:string" use="optional"/>
+            <xs:attribute name="id" type="xs:string" use="optional"/>
+            <xs:attribute name="package" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
Hi,

Since it will be useful for some people (including me), I've added the logic to parse JUnit test results.

So far the files I've been able to test are properly parsed.

I've added a couple of things:

Latest JUnit.xsd file schema attached to the project for validation of JUnit test results XML files.
Added IParser implementation for JUnit using similar code to what already exists in the project (using Linq to XML)
Added small XElement extension method so as to not repeat the if (null) logic everytime we read an attribute from the document.
Have a look at the code and if you have any questions or would like something changed let me know.

Cheers.