### PR TITLE
Add NUnit 'output' in fixture status message + a few other improvements

### DIFF
--- a/ReportUnit/Parser/NUnit.cs
+++ b/ReportUnit/Parser/NUnit.cs
@@ -136,6 +136,12 @@ namespace ReportUnit.Parser
                     }
                 }
 
+                var output = ts.Element("output")?.Value;
+                if (!string.IsNullOrWhiteSpace(output))
+                {
+                    testSuite.StatusMessage +=$"\n\nOutput:\n" + output;
+                }
+
                 // get test suite level categories
                 var suiteCategories = this.GetCategories(ts, false);
 

--- a/ReportUnit/Parser/ParserFactory.cs
+++ b/ReportUnit/Parser/ParserFactory.cs
@@ -50,7 +50,8 @@ namespace ReportUnit.Parser
                     // check if its a mstest 2010 xml file 
                     // will need to check the "//TestRun/@xmlns" attribute - value = http://microsoft.com/schemas/VisualStudio/TeamTest/2010
                     XmlNode testRunNode = doc.SelectSingleNode("ns:TestRun", nsmgr);
-                    if (testRunNode != null && testRunNode.Attributes != null && testRunNode.Attributes["xmlns"] != null && testRunNode.Attributes["xmlns"].InnerText.Contains("2010"))
+                    if (testRunNode != null && testRunNode.Attributes != null && testRunNode.Attributes["xmlns"] != null &&
+                        testRunNode.Attributes["xmlns"].InnerText.Contains("2010"))
                     {
                         return TestRunner.MSTest2010;
                     }
@@ -95,14 +96,18 @@ namespace ReportUnit.Parser
                     // NOTE: not all nunit test files (ie when have nunit output format from other test runners) will contain the environment node
                     //            but if it does exist - then it should have the nunit-version attribute
                     XmlNode envNode = doc.SelectSingleNode("//environment");
-                    if (envNode != null && envNode.Attributes != null && envNode.Attributes["nunit-version"] != null) return TestRunner.NUnit;
+                    if (envNode != null && envNode.Attributes != null && envNode.Attributes["nunit-version"] != null)
+                        return TestRunner.NUnit;
 
                     // check for test-suite nodes - if it has those - its probably nunit tests
                     var testSuiteNodes = doc.SelectNodes("//test-suite");
                     if (testSuiteNodes != null && testSuiteNodes.Count > 0) return TestRunner.NUnit;
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                logger.Warning($"Error when trying to determine testrunner for file {filePath}: {ex.Message}");
+            }
 
             return TestRunner.Unknown;
         }
@@ -110,10 +115,10 @@ namespace ReportUnit.Parser
         private bool ValidateJUnitXsd(XmlDocument doc)
         {
             XmlSchemaSet schema = new XmlSchemaSet();
-            var file = new FileStream(@"Schemas\junit.xsd", FileMode.Open);
-            
+            var file = new FileStream(@"Schemas\junit.xsd", FileMode.Open); //TODO: Embed that as a resource in the .exe so we do not rely on extra files in the folder...
+
             schema.Add("", XmlReader.Create(file));
-            
+
             doc.Schemas.Add(schema);
             doc.Schemas.Compile();
             doc.Validate((s, o) =>

--- a/ReportUnit/Templates/File.cs
+++ b/ReportUnit/Templates/File.cs
@@ -320,18 +320,20 @@ namespace ReportUnit.Templates
                         <div class='hidden total-errors'><!--%ERRORS%--></div>
                         <div class='hidden total-skipped'><!--%SKIPPED%--></div>
                     </div>
-                    <div id='dynamicModal' class='modal modal-trigger' in_duration='0' induration='0'>
+                    <div id='dynamicModal' class='modal' in_duration='0' induration='0'>
                         <div class='modal-content'>
                             <h4></h4>
                             <pre></pre>
                         </div>
-                    </div>
+                        <div class='modal-footer'>
+                            <a href='#!' class='modal-action modal-close waves-effect waves-green btn-flat'>Close</a>
+                        </div>
+                     </div>
                 </body>
                 <script src='https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js'></script> 
                 <script src='https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.2/js/materialize.min.js'></script> 
                 <script src='https://cdnjs.cloudflare.com/ajax/libs/Chart.js/1.0.2/Chart.min.js'></script>
                 <script src='https://cdn.rawgit.com/reportunit/reportunit/005dcf934c5a53e60b9ec88a2a118930b433c453/cdn/reportunit.js' type='text/javascript'></script>
-
             </html>
             ".Replace("\r\n", "").Replace("\t", "").Replace("    ", ""); 
         }

--- a/ReportUnit/Templates/File.cs
+++ b/ReportUnit/Templates/File.cs
@@ -185,16 +185,18 @@ namespace ReportUnit.Templates
                                                             <span alt='Suite started at time' title='Suite started at time' class='startedAt label green lighten-2 text-white'>@Model.TestSuiteList[ix].StartTime</span>
                                                             @if (!String.IsNullOrEmpty(@Model.TestSuiteList[ix].EndTime))
                                                             {
-                                                                <span alt='Suite ended at time' title='Suite ended at time' class='endedAt label label red lighten-2 text-white'>@Model.TestSuiteList[ix].EndTime</span>
+                                                                <span alt='Suite ended at time' title='Suite ended at time' class='endedAt label label brown lighten-2 text-white'>@Model.TestSuiteList[ix].EndTime</span>
                                                             }
                                                             <div class='fixture-status-message'>
                                                                 @if (!String.IsNullOrEmpty(@Model.TestSuiteList[ix].Description)) 
                                                                 {
                                                                     <div class='suite-desc'>@Model.TestSuiteList[ix].Description</div>
                                                                 }
+                                                                @{var suiteStatusClass = Model.TestSuiteList[ix].Status.ToString() == ""Passed"" ? ""info"" : ""error"";}
                                                                 @if (!String.IsNullOrEmpty(@Model.TestSuiteList[ix].StatusMessage)) 
                                                                 {
-                                                                    <div class='suite-desc'>@Model.TestSuiteList[ix].StatusMessage</div>
+                                                                    <div class='badge showStatusMessage @suiteStatusClass' ><i class='mdi-alert-warning'></i></div>
+                                                                    <pre class='hide'>@Model.TestSuiteList[ix].StatusMessage.Replace(""<"", ""&lt;"").Replace("">"", ""&gt;"")</pre>
                                                                 }
                                                             </div>
                                                             <table class='bordered'>
@@ -246,12 +248,12 @@ namespace ReportUnit.Templates
                                                                                 </td>
                                                                             }
                                                                             @if (Model.TestSuiteList.Count > 0 && Model.TestSuiteList[ix].TestList.Where(x => !String.IsNullOrEmpty(x.StatusMessage)).Count() > 0) 
-                                                                            {
+                                                                            {    
+                                                                                var statusClass = test.Status.ToString() == ""Passed"" ? ""info"" : ""error"";
                                                                                 if (!String.IsNullOrEmpty(@test.StatusMessage)) 
                                                                                 {
-                                                                                    <td>
-                                                                                    
-                                                                                        <div class='badge showStatusMessage error'><i class='mdi-alert-warning'></i></div>
+                                                                                    <td>                                                                                    
+                                                                                        <div class='badge showStatusMessage @statusClass' ><i class='mdi-alert-warning'></i></div>
                                                                                         <pre class='hide'>@test.StatusMessage.Replace(""<"", ""&lt;"").Replace("">"", ""&gt;"")</pre>
                                                                                     </td>
                                                                                 }

--- a/ReportUnit/Templates/File.cs
+++ b/ReportUnit/Templates/File.cs
@@ -34,7 +34,6 @@ namespace ReportUnit.Templates
                     <title>ReportUnit TestRunner Report</title>
                     <link href='https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.2/css/materialize.min.css' rel='stylesheet' type='text/css'>
                     <link href='https://cdn.rawgit.com/reportunit/reportunit/005dcf934c5a53e60b9ec88a2a118930b433c453/cdn/reportunit.css' type='text/css' rel='stylesheet' />
-                    
                 </head>
                 <body>
                     <div class='header'>


### PR DESCRIPTION
- This can be a long string for integration tests, so use the same pattern as for a test
- Change coloring - avoid red color for passing tests.
- Prevent null-reference exception when no tests found - `log.fatal` instead...