### PR TITLE
Fix NullReferenceException in NUnit Parser

### DIFF
--- a/ReportUnit/Parser/NUnit.cs
+++ b/ReportUnit/Parser/NUnit.cs
@@ -202,7 +202,7 @@ namespace ReportUnit.Parser
 
                     // error and other status messages
                     test.StatusMessage = 
-                        tc.Element("failure") != null 
+                        tc.Element("failure") != null && tc.Element("failure").Element("message") != null
                             ? tc.Element("failure").Element("message").Value.Trim()
                             : "";
                     test.StatusMessage += 


### PR DESCRIPTION
This PR prevents a `NullReferenceException` in the NUnit parser by adding a null-check on `//test-case/failure/message` elements.